### PR TITLE
Adds more context about the project on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
+# FUSE Equipamente API
+
 [![Build Status](https://travis-ci.org/agco-fuse/fuse-equipment-api.svg?branch=master)](https://travis-ci.org/agco-fuse/fuse-equipment-api)
-##README
+
+This is an API that consumes the AGCO's Telemetry API, and exposes the Equipament information as a JSON RESTful endpoint.
+It is developed on top of [node.js](https://nodejs.org).
+
+# Executing
+
+The API is requires [node.js](https://nodejs.org/) to be executed, and a C compiler to install some libraries with native bindings.
+
+To start a webserver on a given port, execute the following:
+
+```bash
+npm install # Ensures that dependencies are installed
+PORT=1234 npm start
+```
+
+The server will be running at: http://0.0.0.0:1234
+
+## Developing
+
+The API is requires [node.js](https://nodejs.org/) to be developed.
+
+To start the development server, you can execute:
+
+```bash
+npm install # Ensures that dependencies are installed
+npm run start-dev
+```
+
+This will start a server listening on http://localhost:9090 and will reload the
+server when it noticies file changes.
+
+The codebase contains tests, and to validate changes, you may execute:
+
+```bash
+npm install # Ensures that dependencies are installed
+npm test # Triggers package analisys, lints and tests
+```


### PR DESCRIPTION
This commit includes the following information on `README.md`:

- A small paragraph about the project;
- Execution instructions;
- Development commands.

[Resulting rendering is available here](https://github.com/agco-fuse/fuse-equipment-api/blob/1cd87a61a6480159fef92ca6de82286d4552dfed/README.md)