### PR TITLE
Remove warnings on test

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,10 +6,10 @@ import Vision from 'vision';
 import Hapi from 'hapi';
 import HapiSwagger from 'hapi-swagger';
 
-const server = new Hapi.Server();
 const PORT = process.env.PORT || 9090;
 
 const app = (httpClient, telemetryAPI) => {
+  const server = new Hapi.Server();
   const equipmentController = new EquipmentController(httpClient, telemetryAPI);
   const equipmentValidator = new EquipmentValidator();
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,8 +6,6 @@ import Bluebird from 'bluebird';
 
 global.FUSE_TELEMETRY_API_URL = 'http://localhost:9000';
 global.expect = chai.expect;
-global.httpClient = td.function();
-global.server = app(httpClient, FUSE_TELEMETRY_API_URL);
 global.td = td;
 
 global.respondWithSuccess = (requestPromiseMock, result) => {
@@ -17,3 +15,8 @@ global.respondWithSuccess = (requestPromiseMock, result) => {
 global.respondWithFailure = (requestPromiseMock, result) => {
   td.when(requestPromiseMock).thenDo(() => Bluebird.reject(result));
 };
+
+beforeEach(() => {
+  global.httpClient = td.function();
+  global.server = app(httpClient, FUSE_TELEMETRY_API_URL);
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
---require test/helpers.js
 --reporter spec
 --compilers js:babel-core/register
 --slow 5000

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -196,7 +196,7 @@ describe('EquipmentController', () => {
             }
           ]
         });
-        td.verify(httpClient(telemetryRequest));
+
         done();
       });
     });

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -276,23 +276,6 @@ describe('EquipmentController', () => {
       }), telemetryReponse);
     });
 
-    it('get request equipment by id with successful authorization header', (done) => {
-      const expectedResponse = {
-        data: generateFacadeEquipment(equipmentId)
-      };
-
-      respondWithSuccess(httpClient(telemetryRequest), {
-        equipment: [generateTelemetryEquipment(equipmentId)],
-        links: {}
-      });
-
-      server.inject(options, (res) => {
-        expect(res.statusCode).to.be.eql(200);
-        expect(JSON.parse(res.payload)).to.be.eql(expectedResponse);
-        done();
-      });
-    });
-
     it('handles an integration point failure smoothly even if it is an HTML page', (done) => {
       const expectedResponse = {
         errors: [{

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -276,6 +276,89 @@ describe('EquipmentController', () => {
       }), telemetryReponse);
     });
 
+    it('get request equipment by id with successful authorization header', (done) => {
+      const expectedResponse = {
+        data: generateFacadeEquipment(equipmentId)
+      };
+
+      respondWithSuccess(httpClient(telemetryRequest), {
+        equipment: [generateTelemetryEquipment(equipmentId)],
+        links: {}
+      });
+
+      let telemetryReponse = {
+        "meta": {
+          "aggregations": {
+            "equip_agg": [
+              {
+                "key": equipmentId,
+                "spn_ag": [
+                  {
+                    "key": "ENGINE_HOURS",
+                    "spn_latest_ag": [
+                      {
+                        "raw": 94774,
+                        "value": "100"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "ENGINE_SPEED",
+                    "spn_latest_ag": [
+                      {
+                        "raw": 13279,
+                        "value": "100"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "key": "a-equipment-id-2",
+                "spn_ag": [
+                  {
+                    "key": "ENGINE_HOURS",
+                    "spn_latest_ag": [
+                      {
+                        "raw": 94774,
+                        "value": "100"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "ENGINE_SPEED",
+                    "spn_latest_ag": [
+                      {
+                        "raw": 13279,
+                        "value": "100"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+
+      let mockedSearchUri = 'https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&links.canVariable.name=ENGINE_HOURS,ENGINE_SPEED,DRIVING_DIRECTION&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=spn_ag%2Ctp_latest_ag&spn_ag.property=links.canVariable.name&spn_ag.aggregations=spn_latest_ag&spn_latest_ag.type=top_hits&spn_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&spn_latest_ag.limit=1&spn_latest_ag.include=canVariable%2CcanVariable.standardUnit&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=' + equipmentId;
+
+      respondWithSuccess(httpClient({
+        method: 'GET',
+        json: true,
+        uri: mockedSearchUri,
+        headers: {
+          'Authorization': authenticationHeader
+        }
+      }), telemetryReponse);
+
+      server.inject(options, (res) => {
+        expect(res.statusCode).to.be.eql(200);
+        expect(JSON.parse(res.payload)).to.be.eql(expectedResponse);
+        done();
+      });
+    });
+
     it('handles an integration point failure smoothly even if it is an HTML page', (done) => {
       const expectedResponse = {
         errors: [{

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -1,3 +1,5 @@
+import './helpers.js';
+
 describe('EquipmentController', () => {
   let authenticationHeader = null;
   let options = {};


### PR DESCRIPTION
Currently on master there are some test cases that are producing some warnings:

<img width="1272" alt="screen shot 2016-04-15 at 4 33 47 pm" src="https://cloud.githubusercontent.com/assets/109474/14572901/eac440a8-0327-11e6-959a-0f37c47ceef2.png">

With this changes, the warnings will be removed:

<img width="680" alt="screen shot 2016-04-15 at 4 33 17 pm" src="https://cloud.githubusercontent.com/assets/109474/14572908/fa573fd4-0327-11e6-8fec-23f3a61426a0.png">

The major changes are:

- HTTP Mock client is being recreated between test scenarios to not get polluted between runs
- Removed mock verification when the exact arguments have been stubbed, in favor of verifying the behavior on the expected output.