### PR TITLE
Add pagination

### DIFF
--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -26,16 +26,13 @@ class EquipmentController {
   }
 
   findAll(request, reply) {
-    let offset = 0;
-    
-    if (request.query && request.query.offset) {
-      offset = request.query.offset;
-    }
+    const offset = request.query.offset || 0;
+    const limit = request.query.limit || 100;
 
     return this.httpClient({
       method: 'GET',
       json: true,
-      url: `${this.telemetryAPI}/equipment?offset=${offset}`,
+      url: `${this.telemetryAPI}/equipment?offset=${offset}&limit=${limit}`,
       headers: {
         Authorization: request.headers.authorization
       }

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -2,6 +2,9 @@ import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
 import EquipmentParser from '../parser/equipmentParser';
 import ResponseHandler from '../handlers/responseHandler';
 
+const DEFAULT_OFFSET = 0;
+const DEFAULT_LIMIT = 100;
+
 const parseEquipments = (equipments, equipmentsInformations) => {
   return equipments.equipment.map((data) => {
     return EquipmentParser.parse(data, equipmentsInformations[data.id]);
@@ -26,8 +29,8 @@ class EquipmentController {
   }
 
   findAll(request, reply) {
-    const offset = request.query.offset || 0;
-    const limit = request.query.limit || 100;
+    const offset = request.query.offset || DEFAULT_OFFSET;
+    const limit = request.query.limit || DEFAULT_LIMIT;
 
     return this.httpClient({
       method: 'GET',

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -26,10 +26,16 @@ class EquipmentController {
   }
 
   findAll(request, reply) {
+    let offset = 0;
+    
+    if (request.query && request.query.offset) {
+      offset = request.query.offset;
+    }
+
     return this.httpClient({
       method: 'GET',
       json: true,
-      url: `${this.telemetryAPI}/equipment`,
+      url: `${this.telemetryAPI}/equipment?offset=${offset}`,
       headers: {
         Authorization: request.headers.authorization
       }

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -5,6 +5,10 @@ describe('EquipmentController', () => {
   let options = {};
   let telemetryRequest = {};
 
+  const generateSearchUrl = (equipmentIds) => {
+    return `https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&links.canVariable.name=ENGINE_HOURS,ENGINE_SPEED,DRIVING_DIRECTION&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=spn_ag%2Ctp_latest_ag&spn_ag.property=links.canVariable.name&spn_ag.aggregations=spn_latest_ag&spn_latest_ag.type=top_hits&spn_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&spn_latest_ag.limit=1&spn_latest_ag.include=canVariable%2CcanVariable.standardUnit&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=${equipmentIds.join(',')}`;
+  };
+
   const generateFacadeEquipment = (equipmentId) => {
     return readFixture('facadeEquipment', { id: equipmentId});
   };
@@ -47,11 +51,63 @@ describe('EquipmentController', () => {
       };
     });
 
+    it('should allow offset pagination parameter', (done) => {
+      const searchResponse = readFixture('telemetrySearch');
+      searchResponse.meta.aggregations.equip_agg[0].key = 'a-equipment-id-1';
+      searchResponse.meta.aggregations.equip_agg[1].key = 'a-equipment-id-2';
+      const mockedSearchUri = generateSearchUrl(['a-equipment-id-1', 'a-equipment-id-2']);
+      const searchRequest = {
+        method: 'GET',
+        json: true,
+        uri: mockedSearchUri,
+        headers: {
+          'Authorization': authenticationHeader
+        }
+      };
+      respondWithSuccess(httpClient(searchRequest), searchResponse);
+
+      const equipmentResponse = {
+        equipment: [
+          generateTelemetryEquipment('a-equipment-id-1'),
+          generateTelemetryEquipment('a-equipment-id-2')
+        ],
+        links: {}
+      };
+      const equipmentRequest = {
+        method: 'GET',
+        json: true,
+        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=11`,
+        headers: {
+          Authorization: authenticationHeader
+        }
+      };
+      respondWithSuccess(httpClient(equipmentRequest), equipmentResponse);
+
+      const expectedResponse = {
+        data: [
+          generateFacadeEquipment('a-equipment-id-1'),
+          generateFacadeEquipment('a-equipment-id-2')
+        ]
+      };
+      const equipmentOffsetRequest = {
+        url: '/equipment?offset=11',
+        method: 'GET',
+        headers: {
+          Authorization: authenticationHeader
+        }
+      };
+      server.inject(equipmentOffsetRequest, (res) => {
+        expect(res.statusCode).to.be.eql(200);
+        expect(JSON.parse(res.payload)).to.be.eql(expectedResponse);
+        done();
+      });
+    });
+
     it('request telemetry api and receiving equipments', (done) => {
       telemetryRequest = {
         method: 'GET',
         json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment`,
+        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=0`,
         headers: {
           Authorization: authenticationHeader
         }
@@ -61,7 +117,7 @@ describe('EquipmentController', () => {
       telemetryReponse.meta.aggregations.equip_agg[0].key = 'a-equipment-id-1';
       telemetryReponse.meta.aggregations.equip_agg[1].key = 'a-equipment-id-2';
 
-      let mockedSearchUri = 'https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&links.canVariable.name=ENGINE_HOURS,ENGINE_SPEED,DRIVING_DIRECTION&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=spn_ag%2Ctp_latest_ag&spn_ag.property=links.canVariable.name&spn_ag.aggregations=spn_latest_ag&spn_latest_ag.type=top_hits&spn_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&spn_latest_ag.limit=1&spn_latest_ag.include=canVariable%2CcanVariable.standardUnit&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=a-equipment-id-1,a-equipment-id-2';
+      let mockedSearchUri = generateSearchUrl(['a-equipment-id-1', 'a-equipment-id-2']);
 
       respondWithSuccess(httpClient({
         method: 'GET',
@@ -138,7 +194,7 @@ describe('EquipmentController', () => {
           Authorization: authenticationHeader
         }
       };
-      
+
       let telemetryResponse = readFixture('telemetrySearch');
       telemetryResponse.meta.aggregations.equip_agg[0].key = '1-2-3-a';
       delete telemetryResponse.meta.aggregations.equip_agg[1];
@@ -148,9 +204,9 @@ describe('EquipmentController', () => {
           'ENGINE_HOURS': '17059320',
           'ENGINE_SPEED': '1659.875'
         }
-      }
+      };
 
-      let mockedSearchUri = 'https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&links.canVariable.name=ENGINE_HOURS,ENGINE_SPEED,DRIVING_DIRECTION&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=spn_ag%2Ctp_latest_ag&spn_ag.property=links.canVariable.name&spn_ag.aggregations=spn_latest_ag&spn_latest_ag.type=top_hits&spn_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&spn_latest_ag.limit=1&spn_latest_ag.include=canVariable%2CcanVariable.standardUnit&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=1-2-3-a';
+      let mockedSearchUri = generateSearchUrl(['1-2-3-a']);
 
       respondWithSuccess(httpClient({
         method: 'GET',
@@ -225,9 +281,9 @@ describe('EquipmentController', () => {
             ]
           }
         }
-      }
+      };
 
-      let mockedSearchUri = 'https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&links.canVariable.name=ENGINE_HOURS,ENGINE_SPEED,DRIVING_DIRECTION&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=spn_ag%2Ctp_latest_ag&spn_ag.property=links.canVariable.name&spn_ag.aggregations=spn_latest_ag&spn_latest_ag.type=top_hits&spn_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&spn_latest_ag.limit=1&spn_latest_ag.include=canVariable%2CcanVariable.standardUnit&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=' + equipmentId;
+      let mockedSearchUri = generateSearchUrl([equipmentId]);
 
       respondWithSuccess(httpClient({
         method: 'GET',

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -51,7 +51,7 @@ describe('EquipmentController', () => {
       };
     });
 
-    it('should allow offset pagination parameter', (done) => {
+    it('should allow offset and limit pagination parameters', (done) => {
       const searchResponse = readFixture('telemetrySearch');
       searchResponse.meta.aggregations.equip_agg[0].key = 'a-equipment-id-1';
       searchResponse.meta.aggregations.equip_agg[1].key = 'a-equipment-id-2';
@@ -76,7 +76,7 @@ describe('EquipmentController', () => {
       const equipmentRequest = {
         method: 'GET',
         json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=11`,
+        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=11&limit=50`,
         headers: {
           Authorization: authenticationHeader
         }
@@ -90,7 +90,7 @@ describe('EquipmentController', () => {
         ]
       };
       const equipmentOffsetRequest = {
-        url: '/equipment?offset=11',
+        url: '/equipment?offset=11&limit=50',
         method: 'GET',
         headers: {
           Authorization: authenticationHeader
@@ -107,7 +107,7 @@ describe('EquipmentController', () => {
       telemetryRequest = {
         method: 'GET',
         json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=0`,
+        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=0&limit=100`,
         headers: {
           Authorization: authenticationHeader
         }


### PR DESCRIPTION
This change includes pagination for equipments.
Now you can provide an `offset` and/or  `limit` parameters to paginate through your equipment list.
If the user don't provide any of these, we are assuming `offset = 0` and `limit = 100`.