### PR TITLE
Refactoring tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,9 +8,9 @@ import Vision from 'vision';
 import Hapi from 'hapi';
 import HapiSwagger from 'hapi-swagger';
 
-const app = (httpClient, telemetryAPI) => {
+const app = (httpClient, telemetryAPI, canVariablesFetcher) => {
   const server = new Hapi.Server();
-  const equipmentController = new EquipmentController(httpClient, telemetryAPI);
+  const equipmentController = new EquipmentController(httpClient, telemetryAPI, canVariablesFetcher);
 
   server.connection({
     host: '0.0.0.0',

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -1,4 +1,3 @@
-import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
 import EquipmentParser from '../parser/equipmentParser';
 import ResponseHandler from '../handlers/responseHandler';
 
@@ -22,10 +21,10 @@ const responseWithEquipments = (reply) => (equipments, equipmentsInformations) =
 };
 
 class EquipmentController {
-  constructor(httpClient, telemetryAPI) {
+  constructor(httpClient, telemetryAPI, canVariablesFetcher) {
     this.httpClient = httpClient;
     this.telemetryAPI = telemetryAPI;
-    this.canVariablesFetcher = new CanVariablesFetcher(httpClient);
+    this.canVariablesFetcher = canVariablesFetcher;
   }
 
   findAll(request, reply) {

--- a/main.js
+++ b/main.js
@@ -1,8 +1,10 @@
 import app from './app';
 import rp from 'request-promise';
 import config from './config.js';
+import CanVariablesFetcher from './fetcher/canVariablesFetcher';
 
-const server = app(rp, config.TELEMETRY_API_URL);
+const canVariablesFetcher = new CanVariablesFetcher(rp);
+const server = app(rp, config.TELEMETRY_API_URL, canVariablesFetcher);
 
 server.start((err) => {
   if (err) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,6 +4,7 @@ import app from '../app';
 import td from 'testdouble';
 import Bluebird from 'bluebird';
 import fs from 'fs';
+import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
 
 global.FUSE_TELEMETRY_API_URL = 'http://localhost:9000';
 global.expect = chai.expect;
@@ -24,5 +25,6 @@ global.readFixture = (fixtureName, partialObject) => {
 
 beforeEach(() => {
   global.httpClient = td.function();
-  global.server = app(httpClient, FUSE_TELEMETRY_API_URL);
+  const canVariablesFetcher = new CanVariablesFetcher(httpClient);
+  global.server = app(httpClient, FUSE_TELEMETRY_API_URL, canVariablesFetcher);
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,6 +25,6 @@ global.readFixture = (fixtureName, partialObject) => {
 
 beforeEach(() => {
   global.httpClient = td.function();
-  const canVariablesFetcher = new CanVariablesFetcher(httpClient);
+  global.canVariablesFetcher = td.object(CanVariablesFetcher);
   global.server = app(httpClient, FUSE_TELEMETRY_API_URL, canVariablesFetcher);
 });

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -77,15 +77,15 @@ describe('EquipmentController', () => {
       const equipmentOne = generateFacadeEquipment('a-equipment-id-1');
       let equipmentTwo = generateFacadeEquipment('a-equipment-id-2');
       equipmentTwo.attributes.trackingPoint = {
-        "location": {
-          "coordinates": [
+        'location': {
+          'coordinates': [
             0.9392138888888889,
             52.6362222,
             116
           ],
-          "type": "Point"
+          'type': 'Point'
         },
-        "status": "STOPPEDIDLE"
+        'status': 'STOPPEDIDLE'
       };
 
       respondWithSuccess(
@@ -122,15 +122,15 @@ describe('EquipmentController', () => {
       const equipmentOne = generateFacadeEquipment('a-equipment-id-1');
       let equipmentTwo = generateFacadeEquipment('a-equipment-id-2');
       equipmentTwo.attributes.trackingPoint = {
-        "location": {
-          "coordinates": [
+        'location': {
+          'coordinates': [
             0.9392138888888889,
             52.6362222,
             116
           ],
-          "type": "Point"
+          'type': 'Point'
         },
-        "status": "STOPPEDIDLE"
+        'status': 'STOPPEDIDLE'
       };
 
       respondWithSuccess(

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -216,119 +216,26 @@ describe('EquipmentController', () => {
           Authorization: authenticationHeader
         }
       };
-
-      let telemetryResponse = readFixture('telemetrySearch');
-      telemetryResponse.meta.aggregations.equip_agg[0].key = '1-2-3-a';
-      delete telemetryResponse.meta.aggregations.equip_agg[1];
-
-      let expectedResponse = {
-        '1-2-3-a': {
-          'ENGINE_HOURS': '17059320',
-          'ENGINE_SPEED': '1659.875'
-        }
-      };
-
-      let mockedSearchUri = generateSearchUrl(['1-2-3-a']);
-
-      respondWithSuccess(httpClient({
-        method: 'GET',
-        json: true,
-        uri: mockedSearchUri,
-        headers: {
-          'Authorization': authenticationHeader
-        }
-      }), telemetryResponse);
     });
 
     it('get request equipment by id with successful authorization header', (done) => {
-      const expectedResponse = {
-        data: generateFacadeEquipment(equipmentId)
-      };
+      const expectedEquipment = generateFacadeEquipment(equipmentId);
+
+      respondWithSuccess(
+        canVariablesFetcher.fetchByEquipmentId(['1-2-3-a'], authenticationHeader),
+        {
+          '1-2-3-a': { trackingData: expectedEquipment.attributes.trackingData, trackingPoint: expectedEquipment.attributes.trackingPoint },
+        }
+      );
 
       respondWithSuccess(httpClient(telemetryRequest), {
         equipment: [generateTelemetryEquipment(equipmentId)],
         links: {}
       });
 
-      let telemetryReponse = {
-        "meta": {
-          "aggregations": {
-            "equip_agg": [
-              {
-                "key": equipmentId,
-                "spn_ag": [
-                  {
-                    "key": "ENGINE_HOURS",
-                    "spn_latest_ag": [
-                      {
-                        "raw": 94774,
-                        "value": "100"
-                      }
-                    ]
-                  },
-                  {
-                    "key": "ENGINE_SPEED",
-                    "spn_latest_ag": [
-                      {
-                        "raw": 13279,
-                        "value": "100"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "key": "a-equipment-id-2",
-                "spn_ag": [
-                  {
-                    "key": "ENGINE_HOURS",
-                    "spn_latest_ag": [
-                      {
-                        "raw": 94774,
-                        "value": "100"
-                      }
-                    ]
-                  },
-                  {
-                    "key": "ENGINE_SPEED",
-                    "spn_latest_ag": [
-                      {
-                        "raw": 13279,
-                        "value": "100"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
+      const expectedResponse = {
+        data: expectedEquipment
       };
-
-      let trackingPointResponse = readFixture('trackingPoint');
-      trackingPointResponse.linked.trackingPoints[0].links.equipment = equipmentId;
-      trackingPointResponse.meta.aggregations.equip_agg[0].key = equipmentId;
-      delete trackingPointResponse.meta.aggregations.equip_agg[1];
-      let mockedSearchUri = generateSearchUrl([equipmentId]);
-      const mockedSearchTrackingPointUri = generateTrackingPointSearchUrl([equipmentId]); 
-
-      respondWithSuccess(httpClient({
-        method: 'GET',
-        json: true,
-        uri: mockedSearchUri,
-        headers: {
-          'Authorization': authenticationHeader
-        }
-      }), telemetryReponse);
-      
-      respondWithSuccess(httpClient({
-        method: 'GET',
-        json: true,
-        uri: mockedSearchTrackingPointUri,
-        headers: {
-          'Authorization': authenticationHeader
-        }
-      }), trackingPointResponse);
 
       server.inject(options, (res) => {
         expect(res.statusCode).to.be.eql(200);

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -77,15 +77,15 @@ describe('EquipmentController', () => {
       const equipmentOne = generateFacadeEquipment('a-equipment-id-1');
       let equipmentTwo = generateFacadeEquipment('a-equipment-id-2');
       equipmentTwo.attributes.trackingPoint = {
-        'location': {
-          'coordinates': [
+        location: {
+          coordinates: [
             0.9392138888888889,
             52.6362222,
             116
           ],
-          'type': 'Point'
+          type: 'Point'
         },
-        'status': 'STOPPEDIDLE'
+        status: 'STOPPEDIDLE'
       };
 
       respondWithSuccess(
@@ -122,15 +122,15 @@ describe('EquipmentController', () => {
       const equipmentOne = generateFacadeEquipment('a-equipment-id-1');
       let equipmentTwo = generateFacadeEquipment('a-equipment-id-2');
       equipmentTwo.attributes.trackingPoint = {
-        'location': {
-          'coordinates': [
+        location: {
+          coordinates: [
             0.9392138888888889,
             52.6362222,
             116
           ],
-          'type': 'Point'
+          type: 'Point'
         },
-        'status': 'STOPPEDIDLE'
+        status: 'STOPPEDIDLE'
       };
 
       respondWithSuccess(


### PR DESCRIPTION
We would like to remove the knowledge of dependent URLs from the Controller tests, as the component that makes the request is the one responsible to know this.

On this PR we are injecting the Can Variables Fetcher, so we can mock it during test and remove the HTTP requests from the controller test.

On a follow up PR, we are going to extract a Telemetry Fetcher, and do the same changes on the Controller test then.

Pairing with @andressa.