### PR TITLE
Extract a Equipment Fetcher from controller

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,9 +8,9 @@ import Vision from 'vision';
 import Hapi from 'hapi';
 import HapiSwagger from 'hapi-swagger';
 
-const app = (httpClient, telemetryAPI, canVariablesFetcher) => {
+const app = (equipmentFetcher, canVariablesFetcher) => {
   const server = new Hapi.Server();
-  const equipmentController = new EquipmentController(httpClient, telemetryAPI, canVariablesFetcher);
+  const equipmentController = new EquipmentController(equipmentFetcher, canVariablesFetcher);
 
   server.connection({
     host: '0.0.0.0',

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -22,10 +22,8 @@ const responseWithEquipments = (reply) => (equipments, equipmentsInformations) =
 };
 
 class EquipmentController {
-  constructor(httpClient, telemetryAPI, canVariablesFetcher) {
-    this.httpClient = httpClient;
-    this.telemetryAPI = telemetryAPI;
-    this.equipmentFetcher = new EquipmentFetcher(httpClient);
+  constructor(equipmentFetcher, canVariablesFetcher) {
+    this.equipmentFetcher = equipmentFetcher;
     this.canVariablesFetcher = canVariablesFetcher;
   }
 

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -1,5 +1,6 @@
 import EquipmentParser from '../parser/equipmentParser';
 import ResponseHandler from '../handlers/responseHandler';
+import EquipmentFetcher from '../fetcher/equipmentFetcher';
 
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 100;
@@ -24,6 +25,7 @@ class EquipmentController {
   constructor(httpClient, telemetryAPI, canVariablesFetcher) {
     this.httpClient = httpClient;
     this.telemetryAPI = telemetryAPI;
+    this.equipmentFetcher = new EquipmentFetcher(httpClient);
     this.canVariablesFetcher = canVariablesFetcher;
   }
 

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -33,48 +33,43 @@ class EquipmentController {
     const offset = request.query.offset || DEFAULT_OFFSET;
     const limit = request.query.limit || DEFAULT_LIMIT;
 
-    return this.httpClient({
-      method: 'GET',
-      json: true,
-      url: `${this.telemetryAPI}/equipment?offset=${offset}&limit=${limit}`,
-      headers: {
-        Authorization: request.headers.authorization
-      }
-    })
-    .then((equipments) => {
-      const equipmentIds = equipments.equipment.map((equipment) => equipment.id);
-      return this.canVariablesFetcher.fetchByEquipmentId(
-        equipmentIds,
+    this.equipmentFetcher
+      .findAll(
+        offset,
+        limit,
         request.headers.authorization
+      )
+      .then((equipments) => {
+        const equipmentIds = equipments.equipment.map((equipment) => equipment.id);
+        return this.canVariablesFetcher.fetchByEquipmentId(
+          equipmentIds,
+          request.headers.authorization
         )
-      .then((canVariables) => {
-        return [equipments, canVariables];
-      });
-    })
-    .spread(responseWithEquipments(reply))
-    .catch(ResponseHandler.responseWithError(reply));
+        .then((canVariables) => {
+          return [equipments, canVariables];
+        });
+      })
+      .spread(responseWithEquipments(reply))
+      .catch(ResponseHandler.responseWithError(reply));
   }
 
   findById(request, reply) {
-    return this.httpClient({
-      method: 'GET',
-      json: true,
-      url: `${this.telemetryAPI}/equipment/${request.params.id}`,
-      headers: {
-        Authorization: request.headers.authorization
-      }
-    })
-    .then((equipments) => {
-      return this.canVariablesFetcher.fetchByEquipmentId(
-        [equipments.equipment[0].id],
+    this.equipmentFetcher
+      .findById(
+        request.params.id,
         request.headers.authorization
+      )
+      .then((equipments) => {
+        return this.canVariablesFetcher.fetchByEquipmentId(
+          [equipments.equipment[0].id],
+          request.headers.authorization
         )
-      .then((canVariables) => {
-        return [equipments, canVariables];
-      });
-    })
-    .spread(responseWithSingleEquipment(reply))
-    .catch(ResponseHandler.responseWithError(reply));
+        .then((canVariables) => {
+          return [equipments, canVariables];
+        });
+      })
+      .spread(responseWithSingleEquipment(reply))
+      .catch(ResponseHandler.responseWithError(reply));
   }
 }
 

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -1,6 +1,5 @@
 import EquipmentParser from '../parser/equipmentParser';
 import ResponseHandler from '../handlers/responseHandler';
-import EquipmentFetcher from '../fetcher/equipmentFetcher';
 
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 100;
@@ -28,8 +27,8 @@ class EquipmentController {
   }
 
   findAll(request, reply) {
-    const offset = parseInt(request.query.offset) || DEFAULT_OFFSET;
-    const limit = parseInt(request.query.limit) || DEFAULT_LIMIT;
+    const offset = parseInt(request.query.offset, 10) || DEFAULT_OFFSET;
+    const limit = parseInt(request.query.limit, 10) || DEFAULT_LIMIT;
 
     this.equipmentFetcher
       .findAll(

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -28,8 +28,8 @@ class EquipmentController {
   }
 
   findAll(request, reply) {
-    const offset = request.query.offset || DEFAULT_OFFSET;
-    const limit = request.query.limit || DEFAULT_LIMIT;
+    const offset = parseInt(request.query.offset) || DEFAULT_OFFSET;
+    const limit = parseInt(request.query.limit) || DEFAULT_LIMIT;
 
     this.equipmentFetcher
       .findAll(

--- a/fetcher/equipmentFetcher.js
+++ b/fetcher/equipmentFetcher.js
@@ -1,0 +1,10 @@
+import config from '../config';
+
+class EquipmentFetcher {
+  constructor(httpClient) {
+    this.telemetryAPI = config.TELEMETRY_API_URL;
+    this.httpClient = httpClient;
+  }
+}
+
+module.exports = EquipmentFetcher;

--- a/fetcher/equipmentFetcher.js
+++ b/fetcher/equipmentFetcher.js
@@ -5,6 +5,28 @@ class EquipmentFetcher {
     this.telemetryAPI = config.TELEMETRY_API_URL;
     this.httpClient = httpClient;
   }
+
+  findAll(offset, limit, authorizationBearer) {
+    return this.httpClient({
+      method: 'GET',
+      json: true,
+      url: `${this.telemetryAPI}/equipment?offset=${offset}&limit=${limit}`,
+      headers: {
+        Authorization: authorizationBearer
+      }
+    })
+  }
+
+  findById(id, authorizationBearer) {
+    return this.httpClient({
+      method: 'GET',
+      json: true,
+      url: `${this.telemetryAPI}/equipment/${id}`,
+      headers: {
+        Authorization: authorizationBearer
+      }
+    })
+  }
 }
 
 module.exports = EquipmentFetcher;

--- a/main.js
+++ b/main.js
@@ -4,7 +4,8 @@ import config from './config.js';
 import CanVariablesFetcher from './fetcher/canVariablesFetcher';
 
 const canVariablesFetcher = new CanVariablesFetcher(rp);
-const server = app(rp, config.TELEMETRY_API_URL, canVariablesFetcher);
+const equipmentFetcher = new EquipmentFetcher(rp);
+const server = app(equipmentFetcher, canVariablesFetcher);
 
 server.start((err) => {
   if (err) {

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 import app from './app';
 import rp from 'request-promise';
-import config from './config.js';
 import CanVariablesFetcher from './fetcher/canVariablesFetcher';
+import EquipmentFetcher from './fetcher/equipmentFetcher';
 
 const canVariablesFetcher = new CanVariablesFetcher(rp);
 const equipmentFetcher = new EquipmentFetcher(rp);

--- a/test/fetcher/equipmentFetcher_spec.js
+++ b/test/fetcher/equipmentFetcher_spec.js
@@ -1,0 +1,76 @@
+import EquipmentFetcher from '../../fetcher/equipmentFetcher.js';
+
+describe('EquipmentFetcher', () => {
+  let httpClient, equipmentFetcher;
+  const authenticationHeader = 'This is a Bearer token';
+
+  const generateTelemetryEquipment = (equipmentId) => {
+    return {
+      id: equipmentId,
+      description: 'Equipment 1',
+      serviceLevel: 1,
+      identificationNumber: 'a-identification-number',
+      manufacturingDate: '2014-06-30T15:18:51.000Z',
+      links: {
+        dealer: 'a-dealer-id',
+        model: 'a-model-id'
+      }
+    };
+  };
+
+  beforeEach(() => {
+    httpClient = td.function();
+    equipmentFetcher = new EquipmentFetcher(httpClient);
+  });
+
+  it('fetches an equipment list', (done) => {
+    const equipmentResponse = {
+      equipment: [
+        generateTelemetryEquipment('a-equipment-id-1'),
+        generateTelemetryEquipment('a-equipment-id-2'),
+      ],
+      links: {}
+    };
+
+    const equipmentRequest = {
+      method: 'GET',
+      json: true,
+      url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=11&limit=50`,
+      headers: {
+        Authorization: authenticationHeader
+      }
+    };
+    respondWithSuccess(httpClient(equipmentRequest), equipmentResponse);
+
+    equipmentFetcher.findAll(11, 50, authenticationHeader)
+      .then((data) => {
+        expect(data).to.be.eql(equipmentResponse);
+      })
+      .then(done);
+  });
+
+  it('fetches an equipment by id', (done) => {
+    const equipmentResponse = {
+      equipment: [
+        generateTelemetryEquipment('a-equipment-id-1'),
+      ],
+      links: {}
+    };
+
+    const equipmentRequest = {
+      method: 'GET',
+      json: true,
+      url: `${FUSE_TELEMETRY_API_URL}/equipment/a-equipment-id-1`,
+      headers: {
+        Authorization: authenticationHeader
+      }
+    };
+    respondWithSuccess(httpClient(equipmentRequest), equipmentResponse);
+
+    equipmentFetcher.findById('a-equipment-id-1', authenticationHeader)
+      .then((data) => {
+        expect(data).to.be.eql(equipmentResponse);
+      })
+      .then(done);
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,7 +4,7 @@ import td from 'testdouble';
 import Bluebird from 'bluebird';
 import fs from 'fs';
 
-global.FUSE_TELEMETRY_API_URL = 'http://localhost:9000';
+global.FUSE_TELEMETRY_API_URL = 'https://agco-fuse-trackers-sandbox.herokuapp.com';
 global.expect = chai.expect;
 global.td = td;
 

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -4,15 +4,17 @@ import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
 import EquipmentFetcher from '../fetcher/equipmentFetcher';
 
 describe('EquipmentController', () => {
-  let canVariablesFetcher, httpClient, server;
+  let canVariablesFetcher, equipmentFetcher, httpClient, server;
   let options = {};
-  let telemetryRequest = {};
   let authenticationHeader = 'Bearer VALID_TOKEN';
 
   beforeEach(() => {
     httpClient = td.function();
+
     canVariablesFetcher = td.object(CanVariablesFetcher);
-    server = app(new EquipmentFetcher(httpClient), canVariablesFetcher);
+    equipmentFetcher = td.object(EquipmentFetcher);
+
+    server = app(equipmentFetcher, canVariablesFetcher);
   });
 
   const generateFacadeEquipment = (equipmentId) => {
@@ -42,35 +44,19 @@ describe('EquipmentController', () => {
           Authorization: authenticationHeader
         }
       };
-
-      telemetryRequest = {
-        method: 'GET',
-        json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment`,
-        headers: {
-          Authorization: authenticationHeader
-        }
-      };
     });
 
     it('should allow offset and limit pagination parameters', (done) => {
-      const equipmentResponse = {
-        equipment: [
-          generateTelemetryEquipment('a-equipment-id-1'),
-          generateTelemetryEquipment('a-equipment-id-2')
-        ],
-        links: {}
-      };
-
-      const equipmentRequest = {
-        method: 'GET',
-        json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=11&limit=50`,
-        headers: {
-          Authorization: authenticationHeader
+      respondWithSuccess(
+        equipmentFetcher.findAll(11, 50, authenticationHeader),
+        {
+          equipment: [
+            generateTelemetryEquipment('a-equipment-id-1'),
+            generateTelemetryEquipment('a-equipment-id-2'),
+          ],
+          links: {}
         }
-      };
-      respondWithSuccess(httpClient(equipmentRequest), equipmentResponse);
+      );
 
       const equipmentOne = generateFacadeEquipment('a-equipment-id-1');
       let equipmentTwo = generateFacadeEquipment('a-equipment-id-2');
@@ -139,22 +125,16 @@ describe('EquipmentController', () => {
         }
       );
 
-      telemetryRequest = {
-        method: 'GET',
-        json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=0&limit=100`,
-        headers: {
-          Authorization: authenticationHeader
+      respondWithSuccess(
+        equipmentFetcher.findAll(0, 100, authenticationHeader),
+        {
+          equipment: [
+            generateTelemetryEquipment('a-equipment-id-1'),
+            generateTelemetryEquipment('a-equipment-id-2'),
+          ],
+          links: {}
         }
-      };
-
-      respondWithSuccess(httpClient(telemetryRequest), {
-        equipment: [
-          generateTelemetryEquipment('a-equipment-id-1'),
-          generateTelemetryEquipment('a-equipment-id-2'),
-        ],
-        links: {}
-      });
+      );
 
       const expectedResponse = {
         data: [
@@ -171,12 +151,15 @@ describe('EquipmentController', () => {
     });
 
     it('request telemetry api with same authorization header and get an error', (done) => {
-      respondWithFailure(httpClient(telemetryRequest), {
-        response: {
-          statusCode: 401,
-          body: 'Unauthorized'
+      respondWithFailure(
+        equipmentFetcher.findAll(0, 100, authenticationHeader),
+        {
+          response: {
+            statusCode: 401,
+            body: 'Unauthorized'
+          }
         }
-      });
+      );
 
       server.inject(options, (res) => {
         expect(res.statusCode).to.be.eql(401);
@@ -205,15 +188,6 @@ describe('EquipmentController', () => {
           Authorization: authenticationHeader
         }
       };
-
-      telemetryRequest = {
-        method: 'GET',
-        json: true,
-        url: `${FUSE_TELEMETRY_API_URL}/equipment/${equipmentId}`,
-        headers: {
-          Authorization: authenticationHeader
-        }
-      };
     });
 
     it('get request equipment by id with successful authorization header', (done) => {
@@ -226,10 +200,13 @@ describe('EquipmentController', () => {
         }
       );
 
-      respondWithSuccess(httpClient(telemetryRequest), {
-        equipment: [generateTelemetryEquipment(equipmentId)],
-        links: {}
-      });
+      respondWithSuccess(
+        equipmentFetcher.findById(equipmentId, authenticationHeader),
+        {
+          equipment: [generateTelemetryEquipment(equipmentId)],
+          links: {}
+        }
+      );
 
       const expectedResponse = {
         data: expectedEquipment
@@ -252,20 +229,23 @@ describe('EquipmentController', () => {
         }]
       };
 
-      respondWithFailure(httpClient(telemetryRequest), {
-        response: {
-          statusCode: 404,
-          headers: { 'content-type': 'text/html' },
-          body: {
-            errors: [{
-              status: 404,
-              href: 'about:blank',
-              details: 'details...',
-              title: '<!DOCTYPE html>\n<html>\n<body>\nHeroku App Not Found!\n</body>\n</html>'
-            }]
+      respondWithFailure(
+        equipmentFetcher.findById(equipmentId, authenticationHeader),
+        {
+          response: {
+            statusCode: 404,
+            headers: { 'content-type': 'text/html' },
+            body: {
+              errors: [{
+                status: 404,
+                href: 'about:blank',
+                details: 'details...',
+                title: '<!DOCTYPE html>\n<html>\n<body>\nHeroku App Not Found!\n</body>\n</html>'
+              }]
+            }
           }
         }
-      });
+      );
 
       server.inject(options, (res) => {
         expect(res.statusCode).to.be.eql(404);
@@ -282,20 +262,23 @@ describe('EquipmentController', () => {
         }]
       };
 
-      respondWithFailure(httpClient(telemetryRequest), {
-        response: {
-          statusCode: 404,
-          headers: { 'content-type': 'application/json' },
-          body: {
-            errors: [{
-              status: 404,
-              details: 'details...',
-              href: 'about:blank',
-              title: '{ errors: [{ status: 404 }] }'
-            }]
+      respondWithFailure(
+        equipmentFetcher.findById(equipmentId, authenticationHeader),
+        {
+          response: {
+            statusCode: 404,
+            headers: { 'content-type': 'application/json' },
+            body: {
+              errors: [{
+                status: 404,
+                details: 'details...',
+                href: 'about:blank',
+                title: '{ errors: [{ status: 404 }] }'
+              }]
+            }
           }
         }
-      });
+      );
 
       server.inject(options, (res) => {
         expect(res.statusCode).to.be.eql(404);
@@ -314,18 +297,21 @@ describe('EquipmentController', () => {
         }]
       };
 
-      respondWithFailure(httpClient(telemetryRequest), {
-        response: {
-          statusCode: 404,
-          body: {
-            errors: [{
-              status: 404,
-              href: 'about:blank',
-              title: 'Resource not found.'
-            }]
+      respondWithFailure(
+        equipmentFetcher.findById(equipmentId, authenticationHeader),
+        {
+          response: {
+            statusCode: 404,
+            body: {
+              errors: [{
+                status: 404,
+                href: 'about:blank',
+                title: 'Resource not found.'
+              }]
+            }
           }
         }
-      });
+      );
 
       server.inject(options, (res) => {
         expect(res.statusCode).to.be.eql(404);
@@ -344,12 +330,15 @@ describe('EquipmentController', () => {
         ]
       };
 
-      respondWithFailure(httpClient(telemetryRequest), {
-        response: {
-          statusCode: 123,
-          body: 'Error'
+      respondWithFailure(
+        equipmentFetcher.findById(equipmentId, authenticationHeader),
+        {
+          response: {
+            statusCode: 123,
+            body: 'Error'
+          }
         }
-      });
+      );
 
       server.inject(options, (res) => {
         expect(res.statusCode).to.be.eql(500);

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -1,6 +1,7 @@
 import './helpers.js';
 import app from '../app';
 import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
+import EquipmentFetcher from '../fetcher/equipmentFetcher';
 
 describe('EquipmentController', () => {
   let canVariablesFetcher, httpClient, server;
@@ -11,7 +12,7 @@ describe('EquipmentController', () => {
   beforeEach(() => {
     httpClient = td.function();
     canVariablesFetcher = td.object(CanVariablesFetcher);
-    server = app(httpClient, FUSE_TELEMETRY_API_URL, canVariablesFetcher);
+    server = app(new EquipmentFetcher(httpClient), canVariablesFetcher);
   });
 
   const generateFacadeEquipment = (equipmentId) => {


### PR DESCRIPTION
The idea of this PR is to remove the knowledge of HTTP from the controller.

The operations that fetch information from the external APIs are encapsulated into a Fetcher and orchestrated by the Controller.