### PR TITLE
Enabling CORS.

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,11 +10,15 @@ import HapiSwagger from 'hapi-swagger';
 
 const app = (equipmentFetcher, canVariablesFetcher, trackingPointFetcher) => {
   const server = new Hapi.Server();
+
   const equipmentController = new EquipmentController(equipmentFetcher, canVariablesFetcher, trackingPointFetcher);
 
   server.connection({
     host: '0.0.0.0',
-    port: config.PORT
+    port: config.PORT,
+    routes: {
+      cors: true
+    }
   });
 
   server.register([
@@ -51,5 +55,6 @@ const app = (equipmentFetcher, canVariablesFetcher, trackingPointFetcher) => {
 
   return server;
 };
+
 
 module.exports = app;


### PR DESCRIPTION
Given we don't know how our consumers are going to use the Equipment
API, we need to enable CORS.

We are doing it now because Equipment API is only a facade which reads
data from Telemetry API. We would not advise using this if Equipment API
starts inserting data.