### PR TITLE
Adding timeouts to our HTTP requests

### DIFF
--- a/config.js
+++ b/config.js
@@ -53,5 +53,6 @@ module.exports = {
       version: '1.0.0'
     }
   },
-  PORT: process.env.PORT || 9090
+  PORT: process.env.PORT || 9090,
+  TIMEOUT: 10000
 };

--- a/fetcher/canVariablesFetcher.js
+++ b/fetcher/canVariablesFetcher.js
@@ -26,18 +26,19 @@ class CanVariablesFetcher {
   }
 
   fetchByEquipmentId(equipmentIds, authorizationBearer) {
-    let options = {
-      uri: this.urlFor(equipmentIds),
+    let request = {
+      url: this.urlFor(equipmentIds),
       method: 'GET',
       json: true,
       headers: {
         Authorization: authorizationBearer
-      }
+      },
+      timeout: config.TIMEOUT
     };
 
     let equipments = {};
 
-    return this.httpClient(options)
+    return this.httpClient(request)
       .then((data) => {
         data.meta.aggregations.equip_agg.forEach((data, index) => {
           equipments[data.key] = {};

--- a/fetcher/equipmentFetcher.js
+++ b/fetcher/equipmentFetcher.js
@@ -7,25 +7,31 @@ class EquipmentFetcher {
   }
 
   findAll(offset, limit, authorizationBearer) {
-    return this.httpClient({
+    const request = {
+      url: `${this.telemetryAPI}/equipment?offset=${offset}&limit=${limit}`,
       method: 'GET',
       json: true,
-      url: `${this.telemetryAPI}/equipment?offset=${offset}&limit=${limit}`,
       headers: {
         Authorization: authorizationBearer
-      }
-    })
+      },
+      timeout: config.TIMEOUT
+    };
+
+    return this.httpClient(request);
   }
 
   findById(id, authorizationBearer) {
-    return this.httpClient({
+    const request = {
+      url: `${this.telemetryAPI}/equipment/${id}`,
       method: 'GET',
       json: true,
-      url: `${this.telemetryAPI}/equipment/${id}`,
       headers: {
         Authorization: authorizationBearer
-      }
-    })
+      },
+      timeout: config.TIMEOUT
+    };
+
+    return this.httpClient(request);
   }
 }
 

--- a/fetcher/trackingPointFetcher.js
+++ b/fetcher/trackingPointFetcher.js
@@ -20,14 +20,17 @@ class TrackingPointFetcher {
   }
 
   fetchByEquipmentId(equipmentIds, authorizationBearer) {
-    return this.httpClient({
+    const request = {
+      url: this.urlFor(equipmentIds),
       method: 'GET',
       json: true,
-      uri: this.urlFor(equipmentIds),
       headers: {
         Authorization: authorizationBearer
-      }
-    }).then((data) => {
+      },
+      timeout: config.TIMEOUT
+    };
+
+    return this.httpClient(request).then((data) => {
       let equipments = {};
 
       if(data.linked) {

--- a/test/fetcher/canVariablesFetcher_spec.js
+++ b/test/fetcher/canVariablesFetcher_spec.js
@@ -1,4 +1,5 @@
-import CanVariablesFetcher from '../../fetcher/canVariablesFetcher.js';
+import config from '../../config';
+import CanVariablesFetcher from '../../fetcher/canVariablesFetcher';
 
 describe('CanVariablesFetcher', () => {
   let httpClient, canVariablesFetcher;
@@ -47,14 +48,16 @@ describe('CanVariablesFetcher', () => {
     let mockedSearchUri = generateSearchUri('equipment-id-1,equipment-id-2');
     let mockedAuthorizationBearer = 'fake-bearer';
 
-    respondWithSuccess(httpClient({
+    const canVariableRequest = {
+      url: mockedSearchUri,
       method: 'GET',
       json: true,
-      uri: mockedSearchUri,
       headers: {
         Authorization: mockedAuthorizationBearer
-      }
-    }), telemetryResponse);
+      },
+      timeout: config.TIMEOUT
+    };
+    respondWithSuccess(httpClient(canVariableRequest), telemetryResponse);
 
     canVariablesFetcher.fetchByEquipmentId(
         ['equipment-id-1', 'equipment-id-2'],
@@ -73,14 +76,16 @@ describe('CanVariablesFetcher', () => {
     let mockedSearchUri = generateSearchUri('equipment-id-1,equipment-id-2');
     let mockedAuthorizationBearer = 'fake-bearer';
 
-    respondWithSuccess(httpClient({
+    const equipmentRequest = {
+      url: mockedSearchUri,
       method: 'GET',
       json: true,
-      uri: mockedSearchUri,
       headers: {
         Authorization: mockedAuthorizationBearer
-      }
-    }), telemetryResponse);
+      },
+      timeout: config.TIMEOUT
+    };
+    respondWithSuccess(httpClient(equipmentRequest), telemetryResponse);
 
     canVariablesFetcher.fetchByEquipmentId(
         ['equipment-id-1', 'equipment-id-2'],

--- a/test/fetcher/equipmentFetcher_spec.js
+++ b/test/fetcher/equipmentFetcher_spec.js
@@ -1,4 +1,5 @@
-import EquipmentFetcher from '../../fetcher/equipmentFetcher.js';
+import config from '../../config';
+import EquipmentFetcher from '../../fetcher/equipmentFetcher';
 
 describe('EquipmentFetcher', () => {
   let httpClient, equipmentFetcher;
@@ -24,7 +25,8 @@ describe('EquipmentFetcher', () => {
       url: `${FUSE_TELEMETRY_API_URL}/equipment?offset=11&limit=50`,
       headers: {
         Authorization: authenticationHeader
-      }
+      },
+      timeout: config.TIMEOUT
     };
     respondWithSuccess(httpClient(equipmentRequest), equipmentResponse);
 
@@ -44,12 +46,13 @@ describe('EquipmentFetcher', () => {
     };
 
     const equipmentRequest = {
+      url: `${FUSE_TELEMETRY_API_URL}/equipment/a-equipment-id-1`,
       method: 'GET',
       json: true,
-      url: `${FUSE_TELEMETRY_API_URL}/equipment/a-equipment-id-1`,
       headers: {
         Authorization: authenticationHeader
-      }
+      },
+      timeout: config.TIMEOUT
     };
     respondWithSuccess(httpClient(equipmentRequest), equipmentResponse);
 

--- a/test/fetcher/trackingPointFetcher_spec.js
+++ b/test/fetcher/trackingPointFetcher_spec.js
@@ -1,4 +1,5 @@
-import TrackingPointFetcher from '../../fetcher/trackingPointFetcher.js';
+import config from '../../config';
+import TrackingPointFetcher from '../../fetcher/trackingPointFetcher';
 
 describe('TrackingPointFetcher', () => {
   let httpClient, trackingPointFetcher;
@@ -61,14 +62,16 @@ describe('TrackingPointFetcher', () => {
     let mockedSerchTrackingPointUri = 'https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint,trackingPoint.duty&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=tp_latest_ag&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=equipment-id-1,equipment-id-2';
     let mockedAuthorizationBearer = 'fake-bearer';
 
-    respondWithSuccess(httpClient({
+    const trackingPointRequest = {
+      url: mockedSerchTrackingPointUri,
       method: 'GET',
       json: true,
-      uri: mockedSerchTrackingPointUri,
       headers: {
         Authorization: mockedAuthorizationBearer
-      }
-    }), trackingPointResponse);
+      },
+      timeout: config.TIMEOUT
+    };
+    respondWithSuccess(httpClient(trackingPointRequest), trackingPointResponse);
 
     trackingPointFetcher.fetchByEquipmentId(
       ['equipment-id-1', 'equipment-id-2'],
@@ -88,14 +91,16 @@ describe('TrackingPointFetcher', () => {
     let mockedSerchTrackingPointUri = 'https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint,trackingPoint.duty&aggregations=equip_agg&equip_agg.property=links.trackingPoint.equipment.id&equip_agg.aggregations=tp_latest_ag&tp_latest_ag.type=top_hits&tp_latest_ag.sort=-links.trackingPoint.timeOfOccurrence&tp_latest_ag.limit=1&tp_latest_ag.fields=links.trackingPoint&tp_latest_ag.include=trackingPoint&links.trackingPoint.equipment.id=equipment-id-1,equipment-id-2';
     let mockedAuthorizationBearer = 'fake-bearer';
 
-    respondWithSuccess(httpClient({
+    const trackingPointRequest = {
+      url: mockedSerchTrackingPointUri,
       method: 'GET',
       json: true,
-      uri: mockedSerchTrackingPointUri,
       headers: {
         Authorization: mockedAuthorizationBearer
-      }
-    }), trackingPointResponse);
+      },
+      timeout: config.TIMEOUT
+    };
+    respondWithSuccess(httpClient(trackingPointRequest), trackingPointResponse);
 
     trackingPointFetcher.fetchByEquipmentId(
       ['equipment-id-1', 'equipment-id-2'],

--- a/test/models/equipment_spec.js
+++ b/test/models/equipment_spec.js
@@ -1,4 +1,4 @@
-import EquipmentParser from '../../parser/equipmentParser.js';
+import EquipmentParser from '../../parser/equipmentParser';
 
 describe('Equipment model', () => {
   it('should parse equipment with informations', () => {

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -1,4 +1,4 @@
-import './helpers.js';
+import './helpers';
 import app from '../app';
 import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
 import EquipmentFetcher from '../fetcher/equipmentFetcher';


### PR DESCRIPTION
Modern systems integrate with a lot of external dependencies. Most of
these dependencies are outside our control. While requesting content
from one of them, it could happen that it does not reply our
requests. Even worse would be if it decides to answer our requests at a
rate of one byte per second!

What could we do in this case? That is where Timeouts comes to rescue!