### PR TITLE
Adding extra lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,15 @@
 module.exports = {
   'extends': 'agco',
   'plugins': [
-    'standard'
+    'standard',
+    'extra-rules'
   ],
+  'rules': {
+    'extra-rules/no-commented-out-code': 2,
+    'extra-rules/no-for-loops': 2,
+    'extra-rules/no-long-files': [2, 113],
+    'extra-rules/potential-point-free': 2
+  },
   'parserOptions': {
     'sourceType': 'module'
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chai": "^3.5.0",
     "eslint": "^2.8.0",
     "eslint-config-agco": "0.0.3",
+    "eslint-plugin-extra-rules": "^0.6.1",
     "eslint-plugin-standard": "^1.3.2",
     "mocha": "^2.4.5",
     "nodemon": "^1.9.1",


### PR DESCRIPTION
We are including the following lint rules:

- [no-commented-out-code](https://github.com/bahmutov/eslint-rules#no-commented-out-code)
Detects code in the single or multiline comments.
- [no-long-files](https://github.com/bahmutov/eslint-rules#no-long-files)
Detect source files with too many lines.
- [no-for-loops](https://github.com/bahmutov/eslint-rules#no-for-loops)
Warns or errors if you use for loops in your code.
- [potential-point-free](https://github.com/bahmutov/eslint-rules#potential-point-free)
Warns if a function just calls another function passing arguments and
can potentially become point-free.