### PR TITLE
Add support for OPTIONS operation on /equipment endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,14 @@ const app = (equipmentFetcher, canVariablesFetcher, trackingPointFetcher) => {
     }]);
 
   server.route([{
+    method: 'OPTIONS',
+    path: '/equipment',
+    config: {
+      handler: (request, reply) => {
+        equipmentController.options(request, reply);
+      }
+    }
+  }, {
     method: 'GET',
     path: '/equipment',
     config: {

--- a/controllers/equipmentController.js
+++ b/controllers/equipmentController.js
@@ -31,6 +31,10 @@ class EquipmentController {
     this.trackingPointFetcher = trackingPointFetcher;
   }
 
+  options(request, reply) {
+    return reply().header('Allow', 'GET');
+  }
+
   findAll(request, reply) {
     const offset = parseInt(request.query.offset, 10) || DEFAULT_OFFSET;
     const limit = parseInt(request.query.limit, 10) || DEFAULT_LIMIT;

--- a/test/controllers/equipment_controller_spec.js
+++ b/test/controllers/equipment_controller_spec.js
@@ -1,8 +1,8 @@
-import './helpers';
-import app from '../app';
-import CanVariablesFetcher from '../fetcher/canVariablesFetcher';
-import EquipmentFetcher from '../fetcher/equipmentFetcher';
-import TrackingPointFetcher from '../fetcher/trackingPointFetcher';
+import '../helpers';
+import app from '../../app';
+import CanVariablesFetcher from '../../fetcher/canVariablesFetcher';
+import EquipmentFetcher from '../../fetcher/equipmentFetcher';
+import TrackingPointFetcher from '../../fetcher/trackingPointFetcher';
 
 describe('EquipmentController', () => {
   let canVariablesFetcher, equipmentFetcher, trackingPointFetcher, httpClient, server;
@@ -38,6 +38,22 @@ describe('EquipmentController', () => {
       };
     });
 
+    it('should return the list of allowed HTTP methods', (done) => {
+      const optionsRequest = {
+        url: '/equipment',
+        method: 'OPTIONS'
+      };
+
+      const expectedResponse = '';
+
+      server.inject(optionsRequest, (res) => {
+        expect(res.statusCode).to.be.eql(200);
+        expect(res.headers.allow).to.be.eql('GET');
+        expect(res.payload).to.be.eql(expectedResponse);
+        done();
+      });
+    });
+
     it('should allow offset and limit pagination parameters', (done) => {
       respondWithSuccess(
           equipmentFetcher.findAll(11, 50, authenticationHeader),
@@ -68,14 +84,14 @@ describe('EquipmentController', () => {
         canVariablesFetcher.fetchByEquipmentId(['a-equipment-id-1', 'a-equipment-id-2'], authenticationHeader),
         {
           'a-equipment-id-1': equipmentOne.attributes.trackingData,
-          'a-equipment-id-2': equipmentTwo.attributes.trackingData,
+          'a-equipment-id-2': equipmentTwo.attributes.trackingData
         });
 
       respondWithSuccess(
         trackingPointFetcher.fetchByEquipmentId(['a-equipment-id-1', 'a-equipment-id-2'], authenticationHeader),
         {
           'a-equipment-id-1': equipmentOne.attributes.trackingPoint,
-          'a-equipment-id-2': equipmentTwo.attributes.trackingPoint,
+          'a-equipment-id-2': equipmentTwo.attributes.trackingPoint
         });
 
       const expectedResponse = {
@@ -119,14 +135,14 @@ describe('EquipmentController', () => {
         canVariablesFetcher.fetchByEquipmentId(['a-equipment-id-1', 'a-equipment-id-2'], authenticationHeader),
         {
           'a-equipment-id-1': equipmentOne.attributes.trackingData,
-          'a-equipment-id-2': equipmentTwo.attributes.trackingData,
+          'a-equipment-id-2': equipmentTwo.attributes.trackingData
         });
 
       respondWithSuccess(
         trackingPointFetcher.fetchByEquipmentId(['a-equipment-id-1', 'a-equipment-id-2'], authenticationHeader),
         {
           'a-equipment-id-1': equipmentOne.attributes.trackingPoint,
-          'a-equipment-id-2': equipmentTwo.attributes.trackingPoint,
+          'a-equipment-id-2': equipmentTwo.attributes.trackingPoint
         });
 
       respondWithSuccess(
@@ -134,7 +150,7 @@ describe('EquipmentController', () => {
         {
           equipment: [
             generateTelemetryEquipment('a-equipment-id-1'),
-            generateTelemetryEquipment('a-equipment-id-2'),
+            generateTelemetryEquipment('a-equipment-id-2')
           ],
           links: {}
         });


### PR DESCRIPTION
Supporting `OPTIONS` HTTP method might help improving the API
discoverability by external agents.

This allows clients available operations for a given resource.

Previously, if you did an OPTIONS request to /equipment endpoint:

```
$ curl -X OPTIONS --user email@example.com:pass http://fuse-equipment-api.herokuapp.com/equipment          
```

You would receive a response such as:

```
< HTTP/1.1 404 Not Found
< Server: Cowboy
< Connection: keep-alive
< Content-Type: application/json; charset=utf-8
< Cache-Control: no-cache
< Content-Length: 84
< Date: Fri, 20 May 2016 14:47:53 GMT
< Via: 1.1 vegur
<
* Connection #0 to host fuse-equipment-api.herokuapp.com left intact
{"statusCode":404,"error":"Not Found","message":"CORS error: Missing Origin header"}%
```

Now, if you do an OPTIONS request to /equipment endpoint:

```
$ curl -X OPTIONS --user email@example.com:pass http://fuse-equipment-api.herokuapp.com/equipment
```

You would receive a response such as:

```
< HTTP/1.1 200 OK
< Server: Cowboy
< Connection: keep-alive
< allow: GET
< Vary: origin
< Cache-control: no-cache
< Content-length: 0
< Date: Fri, 20 May 2016 14:44:21 GMT
< Via: 1.1 vegur
<
* Connection #0 to host fuse-equipment-api.herokuapp.com left intact
```