### PR TITLE
Add resource description on root ('/') endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+import RootController from './controllers/rootController';
 import EquipmentController from './controllers/equipmentController';
 import EquipmentValidator from './validators/equipment';
 import EquipmentSchema from './schemas/equipmentSchema';
@@ -11,6 +12,7 @@ import HapiSwagger from 'hapi-swagger';
 const app = (equipmentFetcher, canVariablesFetcher, trackingPointFetcher) => {
   const server = new Hapi.Server();
 
+  const rootController = new RootController();
   const equipmentController = new EquipmentController(equipmentFetcher, canVariablesFetcher, trackingPointFetcher);
 
   server.connection({
@@ -30,16 +32,32 @@ const app = (equipmentFetcher, canVariablesFetcher, trackingPointFetcher) => {
     }]);
 
   server.route([{
+    path: '/',
     method: 'OPTIONS',
+    config: {
+      handler: (request, reply) => {
+        rootController.options(request, reply);
+      }
+    }
+  }, {
+    path: '/',
+    method: 'GET',
+    config: {
+      handler: (request, reply) => {
+        rootController.findAll(request, reply);
+      }
+    }
+  }, {
     path: '/equipment',
+    method: 'OPTIONS',
     config: {
       handler: (request, reply) => {
         equipmentController.options(request, reply);
       }
     }
   }, {
-    method: 'GET',
     path: '/equipment',
+    method: 'GET',
     config: {
       handler: (request, reply) => {
         equipmentController.findAll(request, reply);
@@ -49,8 +67,8 @@ const app = (equipmentFetcher, canVariablesFetcher, trackingPointFetcher) => {
       plugins: EquipmentSchema.findAll
     }
   }, {
-    method: 'GET',
     path: '/equipment/{id}',
+    method: 'GET',
     config: {
       handler: (request, reply) => {
         equipmentController.findById(request, reply);

--- a/controllers/rootController.js
+++ b/controllers/rootController.js
@@ -1,0 +1,26 @@
+class RootController {
+  options(request, reply) {
+    return reply().header('Allow', 'GET');
+  }
+
+  findAll(request, reply) {
+    return reply({
+      links: {
+        self: {
+          href: '/',
+          type: 'root'
+        },
+        equipment: {
+          href: '/equipment',
+          type: 'equipment'
+        },
+        docs: {
+          href: '/docs',
+          type: 'documentation'
+        }
+      }
+    });
+  }
+}
+
+module.exports = RootController;

--- a/controllers/rootController.js
+++ b/controllers/rootController.js
@@ -5,6 +5,13 @@ class RootController {
 
   findAll(request, reply) {
     return reply({
+      meta: {
+        description: 'The Equipment API is a façade whose goal is to provide an ' +
+          'easier way of retrieving equipment related structured information. ' +
+          'The equipment information are retrieved from the Telemetry API and ' +
+          'contains the same values, with the structure modeled after the ' +
+          'equipment concept.'
+      },
       links: {
         self: {
           href: '/',

--- a/test/controllers/equipment_controller_spec.js
+++ b/test/controllers/equipment_controller_spec.js
@@ -27,7 +27,7 @@ describe('EquipmentController', () => {
     return readFixture('facadeEquipment', { id: equipmentId});
   };
 
-  describe('Route: equipment', () => {
+  describe('Route: /equipment', () => {
     before(() => {
       options = {
         url: '/equipment',
@@ -195,7 +195,7 @@ describe('EquipmentController', () => {
     });
   });
 
-  describe('Route: equipment/<id>', () => {
+  describe('Route: /equipment/<id>', () => {
     let equipmentId = '1-2-3-a';
 
     before(() => {

--- a/test/controllers/root_controller_spec.js
+++ b/test/controllers/root_controller_spec.js
@@ -38,6 +38,13 @@ describe('RootController', () => {
       };
 
       const expectedResponse = {
+        meta: {
+          description: 'The Equipment API is a façade whose goal is to provide an ' +
+            'easier way of retrieving equipment related structured information. ' +
+            'The equipment information are retrieved from the Telemetry API and ' +
+            'contains the same values, with the structure modeled after the ' +
+            'equipment concept.'
+        },
         links: {
           self: {
             href: '/',

--- a/test/controllers/root_controller_spec.js
+++ b/test/controllers/root_controller_spec.js
@@ -1,0 +1,64 @@
+import app from '../../app';
+import CanVariablesFetcher from '../../fetcher/canVariablesFetcher';
+import EquipmentFetcher from '../../fetcher/equipmentFetcher';
+import TrackingPointFetcher from '../../fetcher/trackingPointFetcher';
+
+describe('RootController', () => {
+  let server;
+
+  beforeEach(() => {
+    const canVariablesFetcher = td.object(CanVariablesFetcher);
+    const equipmentFetcher = td.object(EquipmentFetcher);
+    const trackingPointFetcher = td.object(TrackingPointFetcher);
+
+    server = app(equipmentFetcher, canVariablesFetcher, trackingPointFetcher);
+  });
+
+  describe('Route: /', () => {
+    it('should return the list of allowed HTTP methods', (done) => {
+      const options = {
+        url: '/',
+        method: 'OPTIONS'
+      };
+
+      const expectedResponse = '';
+
+      server.inject(options, (res) => {
+        expect(res.statusCode).to.be.eql(200);
+        expect(res.headers.allow).to.be.eql('GET');
+        expect(res.payload).to.be.eql(expectedResponse);
+        done();
+      });
+    });
+
+    it('should return the list of available resources', (done) => {
+      const options = {
+        url: '/',
+        method: 'GET'
+      };
+
+      const expectedResponse = {
+        links: {
+          self: {
+            href: '/',
+            type: 'root'
+          },
+          equipment: {
+            href: '/equipment',
+            type: 'equipment'
+          },
+          docs: {
+            href: '/docs',
+            type: 'documentation'
+          }
+        }
+      };
+
+      server.inject(options, (res) => {
+        expect(res.statusCode).to.be.eql(200);
+        expect(JSON.parse(res.payload)).to.be.eql(expectedResponse);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Right now root ('/') endpoint requests return a 404 HTTP status
code (Not Found).

That might not be the best behavior for an API in case we want to
improve its discoverability.

This commit includes a RootController whose responsibility is to list
all available resources under the API for external users.

Previously, if you did a GET request to / endpoint:

```
$ curl -X GET --user email@example.com:pass http://fuse-equipment-api.herokuapp.com/         
```

You would receive a response such as:

```
< HTTP/1.1 404 Not Found
< Server: Cowboy
< Connection: keep-alive
< Content-Type: application/json; charset=utf-8
< Cache-Control: no-cache
< Content-Length: 38< Date: Fri, 20 May 2016 16:21:52 GMT
< Via: 1.1 vegur
<
* Connection #0 to host fuse-equipment-api-sandbox.herokuapp.com left intact
{"statusCode":404,"error":"Not Found"}%
```

Now, if you do a GET request to / endpoint:

```
$ curl -X GET --user email@example.com:pass http://fuse-equipment-api.herokuapp.com/
```

You would receive a response such as:

```
< HTTP/1.1 200 OK
< Server: Cowboy
< Connection: keep-alive
< Content-Type: application/json; charset=utf-8
< Cache-control: no-cache
< Content-length: 145
< Date: Fri, 20 May 2016 16:23:01 GMT
< Via: 1.1 vegur
<
* Connection #0 to host fuse-equipment-api-sandbox.herokuapp.com left intact
{"meta": {
  "description": "The Equipment API is a façade whose goal is to provide an easier way of retrieving equipment related structured information.The equipment information are retrieved from the Telemetry API and contains the same values, with the structure modeled after the equipment concept."
},
"data": {},
"links": {
  "self": {
    "href": "/",
    "type": "root"
  },
  "equipment": {
    "href": "/equipment",
    "type":"equipment"
  },
  "docs": {
    "href": "/docs",
    "type": "documentation"
  }
}}%
```