### PR TITLE
Adds CORS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "consumer-contracts": "^1.3.1",
     "cors": "^2.7.1",
     "hapi": "^13.3.0",
+    "hapi-cors-headers": "^1.0.0",
     "hapi-swagger": "^5.0.1",
     "inert": "^3.2.0",
     "joi": "^8.0.5",

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import Inert from 'inert';
 import Vision from 'vision';
 import Hapi from 'hapi';
 import HapiSwagger from 'hapi-swagger';
+import corsHeaders from 'hapi-cors-headers';
 
 import UserInfoTransformer from './metrics/transformers/userInfoTransformer';
 import ResponseTimeTransformer from './metrics/transformers/responseTimeTransformer';
@@ -50,7 +51,10 @@ const app = (equipmentFetcher,
     {
       register: HapiSwagger,
       options: config.HAPI_SWAGGER_CONFIG
-    }]);
+    }
+  ]);
+
+  server.ext('onPreResponse', corsHeaders);
 
   server.route([{
     path: '/',


### PR DESCRIPTION
We thought we had fixed CORS issues a while ago. But it seems that we
haven't.

Today I noticed that the Facade does not support CORS while executing
our dealership demo example.

In order to finally fix this I included a simple hapi plugin which
includes all the necessary CORS headers.