### PR TITLE
Specifies the Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "supertest": "^1.2.0",
     "testdouble": "^1.4.2"
   },
+  "engines": {
+    "node": "6.2.2"
+  },
   "snyk": true
 }


### PR DESCRIPTION
The `engine` section should match the runtime we are using to develop
and test. Given we recently updated our codebase to use Node 6.2.2, we
should make Heroku use this version as well.

For further information, please checkout Heroku documentation: https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version