### PR TITLE
Changes logging logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,6 @@ services:
     image: prima/filebeat
     volumes:
       - ./filebeat/filebeat.yml:/filebeat.yml
-      - ./log/metrics:/var/log/metrics
+      - ./log:/var/log
     depends_on:
       - logstash

--- a/elk/logstash/logstash.conf
+++ b/elk/logstash/logstash.conf
@@ -14,5 +14,6 @@ output {
   elasticsearch {
     hosts => "elasticsearch"
     index => "%{name}-%{+YYYY.MM.dd}"
+    document_type => "%{type}"
   }
 }

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -2,9 +2,8 @@ filebeat:
   prospectors:
     -
       paths:
-        - /var/log/metrics/*.log
+        - /var/log/*.log
       input_type: log
-      document_type: metrics
       scan_frequency: 10s
 output:
   logstash:

--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ const log = bunyan.createLogger({
   name: 'fuse-equipment-api',
   streams: [{
     level: 'info',
-    path: 'log/metrics/request.log'
+    path: 'log/equipment-api.log'
   }]
 });
 

--- a/src/metrics/responseTimeExtractor.js
+++ b/src/metrics/responseTimeExtractor.js
@@ -1,7 +1,8 @@
 const defaultInformation = {
   metricUnit: 'miliseconds',
   description: 'Response time in miliseconds',
-  tags: ['response-time', 'equipment-facade']
+  tags: ['response-time', 'equipment-facade'],
+  type: 'metrics'
 };
 
 class ResponseTimeExtractor {

--- a/test/metrics/response_time_extractor_spec.js
+++ b/test/metrics/response_time_extractor_spec.js
@@ -120,7 +120,7 @@ describe('Response time extractor', () => {
     })
     .then(done);
   });
-  
+
   it('should extract type', (done) => {
     responseTimeExtractor.extract(request)
     .then((events) => {

--- a/test/metrics/response_time_extractor_spec.js
+++ b/test/metrics/response_time_extractor_spec.js
@@ -120,6 +120,14 @@ describe('Response time extractor', () => {
     })
     .then(done);
   });
+  
+  it('should extract type', (done) => {
+    responseTimeExtractor.extract(request)
+    .then((events) => {
+      expect(events.type).to.be.eql('metrics');
+    })
+    .then(done);
+  });
 
   it('should extract tags', (done) => {
     responseTimeExtractor.extract(request)


### PR DESCRIPTION
Based on discussions that we had today about the logging responsability, we changed the way that we are writing logs to be more generic.
The responsability to define in which index and type the data will be saved
was moved to logstash.
co-author: @waldemarnt