### PR TITLE
Add elasticsearch template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     image: logstash:2.3.2
     command: logstash -f /etc/logstash/conf.d/logstash.conf
     volumes:
-      - ./elk/logstash:/etc/logstash/conf.d
+      - ./monitoring/logstash:/etc/logstash/conf.d
     ports:
       - "5000:5000"
     links:
@@ -28,7 +28,7 @@ services:
   filebeat:
     image: prima/filebeat
     volumes:
-      - ./filebeat/filebeat.yml:/filebeat.yml
+      - ./monitoring/filebeat/filebeat.yml:/filebeat.yml
       - ./log:/var/log
     depends_on:
       - logstash

--- a/monitoring/logstash/logstash.conf
+++ b/monitoring/logstash/logstash.conf
@@ -15,7 +15,6 @@ output {
     template_overwrite => true
     template_name => "fuse-equipment-api"
     template => "/etc/logstash/conf.d/template.json"
-    manage_template => true
     hosts => "elasticsearch"
     index => "%{name}-%{+YYYY.MM.dd}"
     document_type => "%{type}"

--- a/monitoring/logstash/logstash.conf
+++ b/monitoring/logstash/logstash.conf
@@ -12,6 +12,10 @@ filter {
 
 output {
   elasticsearch {
+    template_overwrite => true
+    template_name => "fuse-equipment-api"
+    template => "/etc/logstash/conf.d/template.json"
+    manage_template => true
     hosts => "elasticsearch"
     index => "%{name}-%{+YYYY.MM.dd}"
     document_type => "%{type}"

--- a/monitoring/logstash/template.json
+++ b/monitoring/logstash/template.json
@@ -16,6 +16,11 @@
           "type": "string",
           "index": "not_analyzed",
           "doc_values": true
+        },
+        "path": {
+          "type": "string",
+          "index": "not_analyzed",
+          "doc_values": true
         }
       }
     }

--- a/monitoring/logstash/template.json
+++ b/monitoring/logstash/template.json
@@ -1,0 +1,23 @@
+{
+  "template": "fuse-equipment-api-*",
+  "order": 1,
+  "mappings": {
+    "metrics": {
+      "_all": {
+        "enabled": false
+      },
+      "properties": {
+        "username": {
+          "type": "string",
+          "index": "not_analyzed",
+          "doc_values": true
+        },
+        "clientID": {
+          "type": "string",
+          "index": "not_analyzed",
+          "doc_values": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Folks @carolinaborim and I we just added a default template to elasticsearch.
This templates ensure that fields like ```email``` and ```uuid``` will be ```not_analyzed```.
We also fixed #68 docker-compose file paths in this commit https://github.com/agco-fuse/fuse-equipment-api/pull/69/commits/6c51b72eca777105aa8faaea3aeb309c3f79567d